### PR TITLE
Feature/project tumour affected table

### DIFF
--- a/plugins/icgc-viewer/js/Store/SeqFeature/icgcSimpleSomaticMutations.js
+++ b/plugins/icgc-viewer/js/Store/SeqFeature/icgcSimpleSomaticMutations.js
@@ -82,8 +82,10 @@ function(
             var headerRow = `
                 <tr>
                     <th style="${thStyle}">Project</th>
+                    <th style="${thStyle}">Site</th>
                     <th style="${thStyle}">Tumour Type</th>
-                    <th style="${thStyle}">Frequency</th> 
+                    <th style="${thStyle}">Tumour Subtype</th>
+                    <th style="${thStyle}"># Donors Affected</th> 
                 </tr>
             `;
 
@@ -97,8 +99,10 @@ function(
                 }
                 var projectRow = `<tr ${trStyle}>
                     <td style="${thStyle}">${this.prettyValue(project)}</td>
+                    <td style="${thStyle}">${this.prettyValue(projects[project].primarySite)}</td>
                     <td style="${thStyle}">${this.prettyValue(projects[project].tumourType)}</td>
-                    <td style="${thStyle}">${this.prettyValue(projectCounts[project][mutationId])}</td>
+                    <td style="${thStyle}">${this.prettyValue(projects[project].tumourSubtype)}</td>
+                    <td style="${thStyle}">${this.prettyValue(projectCounts[project][mutationId]) + ' / ' + projects[project].ssmTestedDonorCount} (${Math.floor((projectCounts[project][mutationId] / projects[project].ssmTestedDonorCount) * 100)}%)</td>
                     </tr>
                 `;
 
@@ -217,7 +221,7 @@ function(
                 searchBaseUrl = searchBaseUrl + '/donors/' + thisB.donor;
             }
 
-            var url = encodeURI(searchBaseUrl +  '/mutations?filters={"mutation":{"location":{"is":["' + ref + ':' + start + '-' + end + '"]}}}&from=1&include=consequences&size=3');
+            var url = encodeURI(searchBaseUrl +  '/mutations?filters={"mutation":{"location":{"is":["' + ref + ':' + start + '-' + end + '"]}}}&from=1&include=consequences&size=500');
             return request(url, {
                 method: 'get',
                 headers: { 'X-Requested-With': null },
@@ -272,8 +276,7 @@ function(
                                     featureCallback(new SimpleFeature(variantObject));
                                     resolve("Success");
                                 })
-                            }
-                            else {
+                            } else {
                                 reject(Error("Failure"));
                             }
                         });

--- a/plugins/icgc-viewer/js/Store/SeqFeature/icgcSimpleSomaticMutations.js
+++ b/plugins/icgc-viewer/js/Store/SeqFeature/icgcSimpleSomaticMutations.js
@@ -102,7 +102,7 @@ function(
                     <td style="${thStyle}">${this.prettyValue(projects[project].primarySite)}</td>
                     <td style="${thStyle}">${this.prettyValue(projects[project].tumourType)}</td>
                     <td style="${thStyle}">${this.prettyValue(projects[project].tumourSubtype)}</td>
-                    <td style="${thStyle}">${this.prettyValue(projectCounts[project][mutationId]) + ' / ' + projects[project].ssmTestedDonorCount} (${Math.floor((projectCounts[project][mutationId] / projects[project].ssmTestedDonorCount) * 100)}%)</td>
+                    <td style="${thStyle}">${this.prettyValue(projectCounts[project][mutationId]) + ' / ' + projects[project].ssmTestedDonorCount} (${Math.round((projectCounts[project][mutationId] / projects[project].ssmTestedDonorCount) * 100)}%)</td>
                     </tr>
                 `;
 

--- a/plugins/icgc-viewer/js/Store/SeqFeature/icgcSimpleSomaticMutations.js
+++ b/plugins/icgc-viewer/js/Store/SeqFeature/icgcSimpleSomaticMutations.js
@@ -78,7 +78,7 @@ function(
          * Creates a table of projects and their associated tumour type and incidence rate for the given mutation
          */
         createProjectIncidenceTable: function(facets) {
-            var thStyle = 'border: 1px solid #e6e6e6; padding: 2rem .4rem;';
+            var thStyle = 'border: 1px solid #e6e6e6; padding: .2rem .2rem;';
             var headerRow = `
                 <tr>
                     <th style="${thStyle}">Project</th>
@@ -87,7 +87,7 @@ function(
                 </tr>
             `;
 
-            var projectTable = '<table style="width: 100%; border-collapse: \'collapse\'; border-spacing: 0;">' + headerRow;
+            var projectTable = '<table style="width: 560px; border-collapse: \'collapse\'; border-spacing: 0;">' + headerRow;
 
             var count = 0;
             for (term of facets.projectId.terms) {
@@ -106,7 +106,7 @@ function(
                 count++;
             }
 
-            projectTable += '/<table>';
+            projectTable += '</table>';
             return projectTable;
 
         },
@@ -116,7 +116,7 @@ function(
          * @param {*} consequences 
          */
         createConsequencesTable: function(consequences) {
-            var thStyle = 'border: 1px solid #e6e6e6; padding: 2rem .4rem;';
+            var thStyle = 'border: 1px solid #e6e6e6; padding: .2rem .2rem;';
             var headerRow = `
                 <tr>
                     <th style="${thStyle}">Gene</th>
@@ -129,7 +129,7 @@ function(
                 </tr>
             `;
 
-            var consequenceTable = '<table style="width: 100%; border-collapse: \'collapse\'; border-spacing: 0;">' + headerRow;
+            var consequenceTable = '<table style="width: 560px; border-collapse: \'collapse\'; border-spacing: 0;">' + headerRow;
 
             var count = 0;
             for (consequence of consequences) {
@@ -152,7 +152,7 @@ function(
                 count++;
             }
 
-            consequenceTable += '/<table>';
+            consequenceTable += '</table>';
             return consequenceTable;
         },
 
@@ -217,7 +217,7 @@ function(
                 searchBaseUrl = searchBaseUrl + '/donors/' + thisB.donor;
             }
 
-            var url = encodeURI(searchBaseUrl +  '/mutations?filters={"mutation":{"location":{"is":["' + ref + ':' + start + '-' + end + '"]}}}&from=1&include=consequences&size=1000');
+            var url = encodeURI(searchBaseUrl +  '/mutations?filters={"mutation":{"location":{"is":["' + ref + ':' + start + '-' + end + '"]}}}&from=1&include=consequences&size=0');
             return request(url, {
                 method: 'get',
                 headers: { 'X-Requested-With': null },

--- a/plugins/icgc-viewer/js/Store/SeqFeature/icgcSimpleSomaticMutations.js
+++ b/plugins/icgc-viewer/js/Store/SeqFeature/icgcSimpleSomaticMutations.js
@@ -98,30 +98,13 @@ function(
                 var projectRow = `<tr ${trStyle}>
                     <td style="${thStyle}">${this.prettyValue(project)}</td>
                     <td style="${thStyle}">${this.prettyValue(projects[project].tumourType)}</td>
-                    <td style="${thStyle}">${this.prettyValue(projects[project].ssmTestedDonorCount)}</td>
+                    <td style="${thStyle}">N/A</td>
                     </tr>
                 `;
 
                 projectTable += projectRow;
                 count++;
             });
-
-            // for (project of projects) {
-            //     console.log(project);
-            //     var trStyle = '';
-            //     if (count % 2 == 0) {
-            //         trStyle = 'style=\"background-color: #f2f2f2\"';
-            //     }
-            //     var projectRow = `<tr ${trStyle}>
-            //         <td style="${thStyle}">${this.prettyValue(term.term)}</td>
-            //         <td style="${thStyle}"></td>
-            //         <td style="${thStyle}">${this.prettyValue(term.count)}</td>
-            //         </tr>
-            //     `;
-
-            //     projectTable += projectRow;
-            //     count++;
-            // }
 
             projectTable += '</table>';
             return projectTable;


### PR DESCRIPTION
Creates a table for each mutation popup, showing each project that includes at least one donor with the mutation, including how many donors from that cohort have the mutation.

Also reduces the number of mutations grabbed at a time from 1000 to 500 due to 2 extra calls being made per mutation. Might make sense to have this as a setting the user can control.