### PR TITLE
instead of fixed version, build dockerfile with branch version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,5 @@ install:
   - cd ../
 
 script:
-  - $(npm bin)/cypress run --record
+  # - $(npm bin)/cypress run --record
+  - $(npm bin)/cypress run

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ install:
   - cd docker
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then docker-compose build --build-arg plugin_version=${TRAVIS_PULL_REQUEST_BRANCH}; fi'
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then docker-compose build --build-arg plugin_version=${TRAVIS_BRANCH}; fi'
-  - docker-compose build --build-arg plugin_version=$TRAVIS_BRANCH
   - docker-compose up -d
   - cd ../
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,16 @@ before_install:
   - cd docker/data
   - curl -o Homo_sapiens.GRCh37.75.dna.chromosome.1.fa.gz http://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.75.dna.chromosome.1.fa.gz
   - gzip -d Homo_sapiens.GRCh37.75.dna.chromosome.1.fa.gz
-  - cd ../
-  - docker-compose build
-  - docker-compose up -d
-  - cd ../
+  - cd ../../
 
 install:
   - npm ci
+  - cd docker
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then docker-compose build --build-arg plugin_version=${TRAVIS_PULL_REQUEST_BRANCH}; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then docker-compose build --build-arg plugin_version=${TRAVIS_BRANCH}; fi'
+  - docker-compose build --build-arg plugin_version=$TRAVIS_BRANCH
+  - docker-compose up -d
+  - cd ../
 
 script:
   - $(npm bin)/cypress run --record

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - npm ci
   - cd docker
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then docker-compose build --build-arg plugin_version=${TRAVIS_PULL_REQUEST_BRANCH}; fi'
-  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then docker-compose build --build-arg plugin_version=${TRAVIS_BRANCH}; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then docker-compose build --build-arg plugin_version=${TRAVIS_BRANCH}; fi'
   - docker-compose build --build-arg plugin_version=$TRAVIS_BRANCH
   - docker-compose up -d
   - cd ../

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,8 +2,10 @@ FROM node:latest
 
 LABEL maintainer="andrew.duncan@oicr.on.ca"
 
+ARG plugin_version=develop
+
 ENV JBROWSE_VERSION 1.16.6
-ENV PLUGIN_VERSION=0.1.7
+ENV PLUGIN_VERSION=$plugin_version
 
 # Install dependencies
 RUN apt-get -qq update --fix-missing

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM node:latest
 
 LABEL maintainer="andrew.duncan@oicr.on.ca"
 
-ARG plugin_version=develop
+ARG plugin_version=master
 
 ENV JBROWSE_VERSION 1.16.6
 ENV PLUGIN_VERSION=$plugin_version


### PR DESCRIPTION
Travis ci will build docker image for testing based on the branch version. This fixes the issue with breaking changes to develop causing tests to fail.