### PR TITLE
add copy button to shareable link dialog

### DIFF
--- a/icgc-viewer/js/View/Track/BaseTrack.js
+++ b/icgc-viewer/js/View/Track/BaseTrack.js
@@ -194,6 +194,17 @@ define(
                     readOnly: true
                 }, details );
 
+            // Create a copy button for text
+            var copyButton = new Button({
+                label: 'Copy',
+                iconClass: 'dijitIconCopy',
+                onClick: function() {
+                    textArea.focus();
+                    textArea.select();
+                    document.execCommand("copy");
+                }
+            }).placeAt(details);
+
             // Create a DOM element for the link
             var linkString = '<a target="_blank" href="' + shareableLink + '">Open in New Tab</a>';
             var linkElement = domConstruct.toDom(linkString);


### PR DESCRIPTION
Shareable link dialog now has a copy button.